### PR TITLE
Implement soft delete for core entities

### DIFF
--- a/biblio/src/main/java/com/biblio/model/Adherent.java
+++ b/biblio/src/main/java/com/biblio/model/Adherent.java
@@ -19,6 +19,8 @@ public class Adherent {
     private Integer id_profil;
     @Column(name = "id_utilisateur")
     private Integer id_utilisateur;
+    @Column(name = "deleted_at")
+    private java.time.LocalDateTime deleted_at;
 
     public Adherent() {
     }
@@ -69,5 +71,13 @@ public class Adherent {
 
     public void setId_utilisateur(Integer id_utilisateur) {
         this.id_utilisateur = id_utilisateur;
+    }
+
+    public java.time.LocalDateTime getDeleted_at() {
+        return deleted_at;
+    }
+
+    public void setDeleted_at(java.time.LocalDateTime deleted_at) {
+        this.deleted_at = deleted_at;
     }
 }

--- a/biblio/src/main/java/com/biblio/model/Etat.java
+++ b/biblio/src/main/java/com/biblio/model/Etat.java
@@ -13,10 +13,14 @@ public class Etat {
     private Integer id_etat;
     @Column(name = "nom")
     private String nom;
+    @Column(name = "deleted_at")
+    private java.time.LocalDateTime deleted_at;
 
     public Etat() {}
     public Integer getId_etat() { return id_etat; }
     public void setId_etat(Integer id_etat) { this.id_etat = id_etat; }
     public String getNom() { return nom; }
     public void setNom(String nom) { this.nom = nom; }
+    public java.time.LocalDateTime getDeleted_at() { return deleted_at; }
+    public void setDeleted_at(java.time.LocalDateTime deleted_at) { this.deleted_at = deleted_at; }
 }

--- a/biblio/src/main/java/com/biblio/model/Exemplaire.java
+++ b/biblio/src/main/java/com/biblio/model/Exemplaire.java
@@ -15,6 +15,8 @@ public class Exemplaire {
     private String code;
     @Column(name = "id_livre")
     private Integer id_livre;
+    @Column(name = "deleted_at")
+    private java.time.LocalDateTime deleted_at;
 
     public Exemplaire() {}
     public Integer getId_exemplaire() { return id_exemplaire; }
@@ -23,4 +25,6 @@ public class Exemplaire {
     public void setCode(String code) { this.code = code; }
     public Integer getId_livre() { return id_livre; }
     public void setId_livre(Integer id_livre) { this.id_livre = id_livre; }
+    public java.time.LocalDateTime getDeleted_at() { return deleted_at; }
+    public void setDeleted_at(java.time.LocalDateTime deleted_at) { this.deleted_at = deleted_at; }
 }

--- a/biblio/src/main/java/com/biblio/model/Livre.java
+++ b/biblio/src/main/java/com/biblio/model/Livre.java
@@ -15,6 +15,8 @@ public class Livre {
     private String titre;
     @Column(name = "auteur")
     private String auteur;
+    @Column(name = "deleted_at")
+    private java.time.LocalDateTime deleted_at;
 
     public Livre() {}
     public Integer getId_livre() { return id_livre; }
@@ -23,4 +25,6 @@ public class Livre {
     public void setTitre(String titre) { this.titre = titre; }
     public String getAuteur() { return auteur; }
     public void setAuteur(String auteur) { this.auteur = auteur; }
+    public java.time.LocalDateTime getDeleted_at() { return deleted_at; }
+    public void setDeleted_at(java.time.LocalDateTime deleted_at) { this.deleted_at = deleted_at; }
 }

--- a/biblio/src/main/java/com/biblio/model/Penalite.java
+++ b/biblio/src/main/java/com/biblio/model/Penalite.java
@@ -15,6 +15,8 @@ public class Penalite {
     private Integer nb_jour_de_penalite;
     @Column(name = "motif")
     private String motif;
+    @Column(name = "deleted_at")
+    private java.time.LocalDateTime deleted_at;
 
     public Penalite() {}
     public Integer getId_penalite() { return id_penalite; }
@@ -23,4 +25,6 @@ public class Penalite {
     public void setNb_jour_de_penalite(Integer nb_jour_de_penalite) { this.nb_jour_de_penalite = nb_jour_de_penalite; }
     public String getMotif() { return motif; }
     public void setMotif(String motif) { this.motif = motif; }
+    public java.time.LocalDateTime getDeleted_at() { return deleted_at; }
+    public void setDeleted_at(java.time.LocalDateTime deleted_at) { this.deleted_at = deleted_at; }
 }

--- a/biblio/src/main/java/com/biblio/model/Profil.java
+++ b/biblio/src/main/java/com/biblio/model/Profil.java
@@ -13,10 +13,14 @@ public class Profil {
     private Integer id_profil;
     @Column(name = "nom")
     private String nom;
+    @Column(name = "deleted_at")
+    private java.time.LocalDateTime deleted_at;
 
     public Profil() {}
     public Integer getId_profil() { return id_profil; }
     public void setId_profil(Integer id_profil) { this.id_profil = id_profil; }
     public String getNom() { return nom; }
     public void setNom(String nom) { this.nom = nom; }
+    public java.time.LocalDateTime getDeleted_at() { return deleted_at; }
+    public void setDeleted_at(java.time.LocalDateTime deleted_at) { this.deleted_at = deleted_at; }
 }

--- a/biblio/src/main/java/com/biblio/model/Regle.java
+++ b/biblio/src/main/java/com/biblio/model/Regle.java
@@ -21,6 +21,8 @@ public class Regle {
     private Integer nb_prolongement_pret_max;
     @Column(name = "nb_jour_prolongement_max")
     private Integer nb_jour_prolongement_max;
+    @Column(name = "deleted_at")
+    private java.time.LocalDateTime deleted_at;
 
     public Regle() {}
     public Integer getId_regle() { return id_regle; }
@@ -35,4 +37,6 @@ public class Regle {
     public void setNb_prolongement_pret_max(Integer nb_prolongement_pret_max) { this.nb_prolongement_pret_max = nb_prolongement_pret_max; }
     public Integer getNb_jour_prolongement_max() { return nb_jour_prolongement_max; }
     public void setNb_jour_prolongement_max(Integer nb_jour_prolongement_max) { this.nb_jour_prolongement_max = nb_jour_prolongement_max; }
+    public java.time.LocalDateTime getDeleted_at() { return deleted_at; }
+    public void setDeleted_at(java.time.LocalDateTime deleted_at) { this.deleted_at = deleted_at; }
 }

--- a/biblio/src/main/java/com/biblio/model/Restriction.java
+++ b/biblio/src/main/java/com/biblio/model/Restriction.java
@@ -13,10 +13,14 @@ public class Restriction {
     private Integer id_restriction;
     @Column(name = "age_min")
     private Integer age_min;
+    @Column(name = "deleted_at")
+    private java.time.LocalDateTime deleted_at;
 
     public Restriction() {}
     public Integer getId_restriction() { return id_restriction; }
     public void setId_restriction(Integer id_restriction) { this.id_restriction = id_restriction; }
     public Integer getAge_min() { return age_min; }
     public void setAge_min(Integer age_min) { this.age_min = age_min; }
+    public java.time.LocalDateTime getDeleted_at() { return deleted_at; }
+    public void setDeleted_at(java.time.LocalDateTime deleted_at) { this.deleted_at = deleted_at; }
 }

--- a/biblio/src/main/java/com/biblio/model/Role.java
+++ b/biblio/src/main/java/com/biblio/model/Role.java
@@ -13,10 +13,14 @@ public class Role {
     private Integer id_role;
     @Column(name = "nom")
     private String nom;
+    @Column(name = "deleted_at")
+    private java.time.LocalDateTime deleted_at;
 
     public Role() {}
     public Integer getId_role() { return id_role; }
     public void setId_role(Integer id_role) { this.id_role = id_role; }
     public String getNom() { return nom; }
     public void setNom(String nom) { this.nom = nom; }
+    public java.time.LocalDateTime getDeleted_at() { return deleted_at; }
+    public void setDeleted_at(java.time.LocalDateTime deleted_at) { this.deleted_at = deleted_at; }
 }

--- a/biblio/src/main/java/com/biblio/model/Typepret.java
+++ b/biblio/src/main/java/com/biblio/model/Typepret.java
@@ -13,10 +13,14 @@ public class Typepret {
     private Integer id_type_pret;
     @Column(name = "nom")
     private String nom;
+    @Column(name = "deleted_at")
+    private java.time.LocalDateTime deleted_at;
 
     public Typepret() {}
     public Integer getId_type_pret() { return id_type_pret; }
     public void setId_type_pret(Integer id_type_pret) { this.id_type_pret = id_type_pret; }
     public String getNom() { return nom; }
     public void setNom(String nom) { this.nom = nom; }
+    public java.time.LocalDateTime getDeleted_at() { return deleted_at; }
+    public void setDeleted_at(java.time.LocalDateTime deleted_at) { this.deleted_at = deleted_at; }
 }

--- a/biblio/src/main/java/com/biblio/model/Utilisateur.java
+++ b/biblio/src/main/java/com/biblio/model/Utilisateur.java
@@ -17,6 +17,8 @@ public class Utilisateur {
     private String mdp;
     @Column(name = "id_role")
     private Integer id_role;
+    @Column(name = "deleted_at")
+    private java.time.LocalDateTime deleted_at;
 
     public Utilisateur() {}
     public Integer getId_utilisateur() { return id_utilisateur; }
@@ -27,4 +29,6 @@ public class Utilisateur {
     public void setMdp(String mdp) { this.mdp = mdp; }
     public Integer getId_role() { return id_role; }
     public void setId_role(Integer id_role) { this.id_role = id_role; }
+    public java.time.LocalDateTime getDeleted_at() { return deleted_at; }
+    public void setDeleted_at(java.time.LocalDateTime deleted_at) { this.deleted_at = deleted_at; }
 }

--- a/biblio/src/main/java/com/biblio/repository/AdherentRepository.java
+++ b/biblio/src/main/java/com/biblio/repository/AdherentRepository.java
@@ -2,6 +2,9 @@ package com.biblio.repository;
 
 import com.biblio.model.Adherent;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.*;
 
 public interface AdherentRepository extends JpaRepository<Adherent, Integer> {
+    List<Adherent> findByDeleted_atIsNull();
+    Optional<Adherent> findByIdAndDeleted_atIsNull(Integer id);
 }

--- a/biblio/src/main/java/com/biblio/repository/EtatRepository.java
+++ b/biblio/src/main/java/com/biblio/repository/EtatRepository.java
@@ -2,6 +2,9 @@ package com.biblio.repository;
 
 import com.biblio.model.Etat;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.*;
 
 public interface EtatRepository extends JpaRepository<Etat, Integer> {
+    List<Etat> findByDeleted_atIsNull();
+    Optional<Etat> findByIdAndDeleted_atIsNull(Integer id);
 }

--- a/biblio/src/main/java/com/biblio/repository/ExemplaireRepository.java
+++ b/biblio/src/main/java/com/biblio/repository/ExemplaireRepository.java
@@ -2,6 +2,9 @@ package com.biblio.repository;
 
 import com.biblio.model.Exemplaire;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.*;
 
 public interface ExemplaireRepository extends JpaRepository<Exemplaire, Integer> {
+    List<Exemplaire> findByDeleted_atIsNull();
+    Optional<Exemplaire> findByIdAndDeleted_atIsNull(Integer id);
 }

--- a/biblio/src/main/java/com/biblio/repository/LivreRepository.java
+++ b/biblio/src/main/java/com/biblio/repository/LivreRepository.java
@@ -2,6 +2,9 @@ package com.biblio.repository;
 
 import com.biblio.model.Livre;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.*;
 
 public interface LivreRepository extends JpaRepository<Livre, Integer> {
+    List<Livre> findByDeleted_atIsNull();
+    Optional<Livre> findByIdAndDeleted_atIsNull(Integer id);
 }

--- a/biblio/src/main/java/com/biblio/repository/PenaliteRepository.java
+++ b/biblio/src/main/java/com/biblio/repository/PenaliteRepository.java
@@ -2,6 +2,9 @@ package com.biblio.repository;
 
 import com.biblio.model.Penalite;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.*;
 
 public interface PenaliteRepository extends JpaRepository<Penalite, Integer> {
+    List<Penalite> findByDeleted_atIsNull();
+    Optional<Penalite> findByIdAndDeleted_atIsNull(Integer id);
 }

--- a/biblio/src/main/java/com/biblio/repository/ProfilRepository.java
+++ b/biblio/src/main/java/com/biblio/repository/ProfilRepository.java
@@ -2,6 +2,9 @@ package com.biblio.repository;
 
 import com.biblio.model.Profil;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.*;
 
 public interface ProfilRepository extends JpaRepository<Profil, Integer> {
+    List<Profil> findByDeleted_atIsNull();
+    Optional<Profil> findByIdAndDeleted_atIsNull(Integer id);
 }

--- a/biblio/src/main/java/com/biblio/repository/RegleRepository.java
+++ b/biblio/src/main/java/com/biblio/repository/RegleRepository.java
@@ -2,6 +2,9 @@ package com.biblio.repository;
 
 import com.biblio.model.Regle;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.*;
 
 public interface RegleRepository extends JpaRepository<Regle, Integer> {
+    List<Regle> findByDeleted_atIsNull();
+    Optional<Regle> findByIdAndDeleted_atIsNull(Integer id);
 }

--- a/biblio/src/main/java/com/biblio/repository/RestrictionRepository.java
+++ b/biblio/src/main/java/com/biblio/repository/RestrictionRepository.java
@@ -2,6 +2,9 @@ package com.biblio.repository;
 
 import com.biblio.model.Restriction;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.*;
 
 public interface RestrictionRepository extends JpaRepository<Restriction, Integer> {
+    List<Restriction> findByDeleted_atIsNull();
+    Optional<Restriction> findByIdAndDeleted_atIsNull(Integer id);
 }

--- a/biblio/src/main/java/com/biblio/repository/RoleRepository.java
+++ b/biblio/src/main/java/com/biblio/repository/RoleRepository.java
@@ -2,6 +2,9 @@ package com.biblio.repository;
 
 import com.biblio.model.Role;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.*;
 
 public interface RoleRepository extends JpaRepository<Role, Integer> {
+    List<Role> findByDeleted_atIsNull();
+    Optional<Role> findByIdAndDeleted_atIsNull(Integer id);
 }

--- a/biblio/src/main/java/com/biblio/repository/TypepretRepository.java
+++ b/biblio/src/main/java/com/biblio/repository/TypepretRepository.java
@@ -2,6 +2,9 @@ package com.biblio.repository;
 
 import com.biblio.model.Typepret;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.*;
 
 public interface TypepretRepository extends JpaRepository<Typepret, Integer> {
+    List<Typepret> findByDeleted_atIsNull();
+    Optional<Typepret> findByIdAndDeleted_atIsNull(Integer id);
 }

--- a/biblio/src/main/java/com/biblio/repository/UtilisateurRepository.java
+++ b/biblio/src/main/java/com/biblio/repository/UtilisateurRepository.java
@@ -2,6 +2,9 @@ package com.biblio.repository;
 
 import com.biblio.model.Utilisateur;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.*;
 
 public interface UtilisateurRepository extends JpaRepository<Utilisateur, Integer> {
+    List<Utilisateur> findByDeleted_atIsNull();
+    Optional<Utilisateur> findByIdAndDeleted_atIsNull(Integer id);
 }

--- a/biblio/src/main/java/com/biblio/service/AdherentServiceImpl.java
+++ b/biblio/src/main/java/com/biblio/service/AdherentServiceImpl.java
@@ -3,6 +3,7 @@ package com.biblio.service;
 import org.springframework.stereotype.Service;
 import org.springframework.beans.factory.annotation.Autowired;
 import java.util.*;
+import java.time.*;
 import com.biblio.repository.AdherentRepository;
 import com.biblio.model.Adherent;
 
@@ -11,8 +12,14 @@ public class AdherentServiceImpl implements AdherentService {
     @Autowired
     private AdherentRepository repo;
 
-    public List<Adherent> findAll() { return repo.findAll(); }
-    public Adherent findById(Integer id) { return repo.findById(id).orElse(null); }
+    public List<Adherent> findAll() { return repo.findByDeleted_atIsNull(); }
+    public Adherent findById(Integer id) { return repo.findByIdAndDeleted_atIsNull(id).orElse(null); }
     public Adherent save(Adherent obj) { return repo.save(obj); }
-    public void deleteById(Integer id) { repo.deleteById(id); }
+    public void deleteById(Integer id) {
+        Adherent obj = repo.findById(id).orElse(null);
+        if(obj != null) {
+            obj.setDeleted_at(LocalDateTime.now());
+            repo.save(obj);
+        }
+    }
 }

--- a/biblio/src/main/java/com/biblio/service/EtatServiceImpl.java
+++ b/biblio/src/main/java/com/biblio/service/EtatServiceImpl.java
@@ -3,6 +3,7 @@ package com.biblio.service;
 import org.springframework.stereotype.Service;
 import org.springframework.beans.factory.annotation.Autowired;
 import java.util.*;
+import java.time.*;
 import com.biblio.repository.EtatRepository;
 import com.biblio.model.Etat;
 
@@ -11,8 +12,14 @@ public class EtatServiceImpl implements EtatService {
     @Autowired
     private EtatRepository repo;
 
-    public List<Etat> findAll() { return repo.findAll(); }
-    public Etat findById(Integer id) { return repo.findById(id).orElse(null); }
+    public List<Etat> findAll() { return repo.findByDeleted_atIsNull(); }
+    public Etat findById(Integer id) { return repo.findByIdAndDeleted_atIsNull(id).orElse(null); }
     public Etat save(Etat obj) { return repo.save(obj); }
-    public void deleteById(Integer id) { repo.deleteById(id); }
+    public void deleteById(Integer id) {
+        Etat obj = repo.findById(id).orElse(null);
+        if(obj != null) {
+            obj.setDeleted_at(LocalDateTime.now());
+            repo.save(obj);
+        }
+    }
 }

--- a/biblio/src/main/java/com/biblio/service/ExemplaireServiceImpl.java
+++ b/biblio/src/main/java/com/biblio/service/ExemplaireServiceImpl.java
@@ -3,6 +3,7 @@ package com.biblio.service;
 import org.springframework.stereotype.Service;
 import org.springframework.beans.factory.annotation.Autowired;
 import java.util.*;
+import java.time.*;
 import com.biblio.repository.ExemplaireRepository;
 import com.biblio.model.Exemplaire;
 
@@ -11,8 +12,14 @@ public class ExemplaireServiceImpl implements ExemplaireService {
     @Autowired
     private ExemplaireRepository repo;
 
-    public List<Exemplaire> findAll() { return repo.findAll(); }
-    public Exemplaire findById(Integer id) { return repo.findById(id).orElse(null); }
+    public List<Exemplaire> findAll() { return repo.findByDeleted_atIsNull(); }
+    public Exemplaire findById(Integer id) { return repo.findByIdAndDeleted_atIsNull(id).orElse(null); }
     public Exemplaire save(Exemplaire obj) { return repo.save(obj); }
-    public void deleteById(Integer id) { repo.deleteById(id); }
+    public void deleteById(Integer id) {
+        Exemplaire obj = repo.findById(id).orElse(null);
+        if(obj != null) {
+            obj.setDeleted_at(LocalDateTime.now());
+            repo.save(obj);
+        }
+    }
 }

--- a/biblio/src/main/java/com/biblio/service/LivreServiceImpl.java
+++ b/biblio/src/main/java/com/biblio/service/LivreServiceImpl.java
@@ -3,6 +3,7 @@ package com.biblio.service;
 import org.springframework.stereotype.Service;
 import org.springframework.beans.factory.annotation.Autowired;
 import java.util.*;
+import java.time.*;
 import com.biblio.repository.LivreRepository;
 import com.biblio.model.Livre;
 
@@ -11,8 +12,14 @@ public class LivreServiceImpl implements LivreService {
     @Autowired
     private LivreRepository repo;
 
-    public List<Livre> findAll() { return repo.findAll(); }
-    public Livre findById(Integer id) { return repo.findById(id).orElse(null); }
+    public List<Livre> findAll() { return repo.findByDeleted_atIsNull(); }
+    public Livre findById(Integer id) { return repo.findByIdAndDeleted_atIsNull(id).orElse(null); }
     public Livre save(Livre obj) { return repo.save(obj); }
-    public void deleteById(Integer id) { repo.deleteById(id); }
+    public void deleteById(Integer id) {
+        Livre obj = repo.findById(id).orElse(null);
+        if(obj != null) {
+            obj.setDeleted_at(LocalDateTime.now());
+            repo.save(obj);
+        }
+    }
 }

--- a/biblio/src/main/java/com/biblio/service/PenaliteServiceImpl.java
+++ b/biblio/src/main/java/com/biblio/service/PenaliteServiceImpl.java
@@ -3,6 +3,7 @@ package com.biblio.service;
 import org.springframework.stereotype.Service;
 import org.springframework.beans.factory.annotation.Autowired;
 import java.util.*;
+import java.time.*;
 import com.biblio.repository.PenaliteRepository;
 import com.biblio.model.Penalite;
 
@@ -11,8 +12,14 @@ public class PenaliteServiceImpl implements PenaliteService {
     @Autowired
     private PenaliteRepository repo;
 
-    public List<Penalite> findAll() { return repo.findAll(); }
-    public Penalite findById(Integer id) { return repo.findById(id).orElse(null); }
+    public List<Penalite> findAll() { return repo.findByDeleted_atIsNull(); }
+    public Penalite findById(Integer id) { return repo.findByIdAndDeleted_atIsNull(id).orElse(null); }
     public Penalite save(Penalite obj) { return repo.save(obj); }
-    public void deleteById(Integer id) { repo.deleteById(id); }
+    public void deleteById(Integer id) {
+        Penalite obj = repo.findById(id).orElse(null);
+        if(obj != null) {
+            obj.setDeleted_at(LocalDateTime.now());
+            repo.save(obj);
+        }
+    }
 }

--- a/biblio/src/main/java/com/biblio/service/ProfilServiceImpl.java
+++ b/biblio/src/main/java/com/biblio/service/ProfilServiceImpl.java
@@ -3,6 +3,7 @@ package com.biblio.service;
 import org.springframework.stereotype.Service;
 import org.springframework.beans.factory.annotation.Autowired;
 import java.util.*;
+import java.time.*;
 import com.biblio.repository.ProfilRepository;
 import com.biblio.model.Profil;
 
@@ -11,8 +12,14 @@ public class ProfilServiceImpl implements ProfilService {
     @Autowired
     private ProfilRepository repo;
 
-    public List<Profil> findAll() { return repo.findAll(); }
-    public Profil findById(Integer id) { return repo.findById(id).orElse(null); }
+    public List<Profil> findAll() { return repo.findByDeleted_atIsNull(); }
+    public Profil findById(Integer id) { return repo.findByIdAndDeleted_atIsNull(id).orElse(null); }
     public Profil save(Profil obj) { return repo.save(obj); }
-    public void deleteById(Integer id) { repo.deleteById(id); }
+    public void deleteById(Integer id) {
+        Profil obj = repo.findById(id).orElse(null);
+        if(obj != null) {
+            obj.setDeleted_at(LocalDateTime.now());
+            repo.save(obj);
+        }
+    }
 }

--- a/biblio/src/main/java/com/biblio/service/RegleServiceImpl.java
+++ b/biblio/src/main/java/com/biblio/service/RegleServiceImpl.java
@@ -3,6 +3,7 @@ package com.biblio.service;
 import org.springframework.stereotype.Service;
 import org.springframework.beans.factory.annotation.Autowired;
 import java.util.*;
+import java.time.*;
 import com.biblio.repository.RegleRepository;
 import com.biblio.model.Regle;
 
@@ -11,8 +12,14 @@ public class RegleServiceImpl implements RegleService {
     @Autowired
     private RegleRepository repo;
 
-    public List<Regle> findAll() { return repo.findAll(); }
-    public Regle findById(Integer id) { return repo.findById(id).orElse(null); }
+    public List<Regle> findAll() { return repo.findByDeleted_atIsNull(); }
+    public Regle findById(Integer id) { return repo.findByIdAndDeleted_atIsNull(id).orElse(null); }
     public Regle save(Regle obj) { return repo.save(obj); }
-    public void deleteById(Integer id) { repo.deleteById(id); }
+    public void deleteById(Integer id) {
+        Regle obj = repo.findById(id).orElse(null);
+        if(obj != null) {
+            obj.setDeleted_at(LocalDateTime.now());
+            repo.save(obj);
+        }
+    }
 }

--- a/biblio/src/main/java/com/biblio/service/RestrictionServiceImpl.java
+++ b/biblio/src/main/java/com/biblio/service/RestrictionServiceImpl.java
@@ -3,6 +3,7 @@ package com.biblio.service;
 import org.springframework.stereotype.Service;
 import org.springframework.beans.factory.annotation.Autowired;
 import java.util.*;
+import java.time.*;
 import com.biblio.repository.RestrictionRepository;
 import com.biblio.model.Restriction;
 
@@ -11,8 +12,14 @@ public class RestrictionServiceImpl implements RestrictionService {
     @Autowired
     private RestrictionRepository repo;
 
-    public List<Restriction> findAll() { return repo.findAll(); }
-    public Restriction findById(Integer id) { return repo.findById(id).orElse(null); }
+    public List<Restriction> findAll() { return repo.findByDeleted_atIsNull(); }
+    public Restriction findById(Integer id) { return repo.findByIdAndDeleted_atIsNull(id).orElse(null); }
     public Restriction save(Restriction obj) { return repo.save(obj); }
-    public void deleteById(Integer id) { repo.deleteById(id); }
+    public void deleteById(Integer id) {
+        Restriction obj = repo.findById(id).orElse(null);
+        if(obj != null) {
+            obj.setDeleted_at(LocalDateTime.now());
+            repo.save(obj);
+        }
+    }
 }

--- a/biblio/src/main/java/com/biblio/service/RoleServiceImpl.java
+++ b/biblio/src/main/java/com/biblio/service/RoleServiceImpl.java
@@ -3,6 +3,7 @@ package com.biblio.service;
 import org.springframework.stereotype.Service;
 import org.springframework.beans.factory.annotation.Autowired;
 import java.util.*;
+import java.time.*;
 import com.biblio.repository.RoleRepository;
 import com.biblio.model.Role;
 
@@ -11,8 +12,14 @@ public class RoleServiceImpl implements RoleService {
     @Autowired
     private RoleRepository repo;
 
-    public List<Role> findAll() { return repo.findAll(); }
-    public Role findById(Integer id) { return repo.findById(id).orElse(null); }
+    public List<Role> findAll() { return repo.findByDeleted_atIsNull(); }
+    public Role findById(Integer id) { return repo.findByIdAndDeleted_atIsNull(id).orElse(null); }
     public Role save(Role obj) { return repo.save(obj); }
-    public void deleteById(Integer id) { repo.deleteById(id); }
+    public void deleteById(Integer id) {
+        Role obj = repo.findById(id).orElse(null);
+        if(obj != null) {
+            obj.setDeleted_at(LocalDateTime.now());
+            repo.save(obj);
+        }
+    }
 }

--- a/biblio/src/main/java/com/biblio/service/TypepretServiceImpl.java
+++ b/biblio/src/main/java/com/biblio/service/TypepretServiceImpl.java
@@ -3,6 +3,7 @@ package com.biblio.service;
 import org.springframework.stereotype.Service;
 import org.springframework.beans.factory.annotation.Autowired;
 import java.util.*;
+import java.time.*;
 import com.biblio.repository.TypepretRepository;
 import com.biblio.model.Typepret;
 
@@ -11,8 +12,14 @@ public class TypepretServiceImpl implements TypepretService {
     @Autowired
     private TypepretRepository repo;
 
-    public List<Typepret> findAll() { return repo.findAll(); }
-    public Typepret findById(Integer id) { return repo.findById(id).orElse(null); }
+    public List<Typepret> findAll() { return repo.findByDeleted_atIsNull(); }
+    public Typepret findById(Integer id) { return repo.findByIdAndDeleted_atIsNull(id).orElse(null); }
     public Typepret save(Typepret obj) { return repo.save(obj); }
-    public void deleteById(Integer id) { repo.deleteById(id); }
+    public void deleteById(Integer id) {
+        Typepret obj = repo.findById(id).orElse(null);
+        if(obj != null) {
+            obj.setDeleted_at(LocalDateTime.now());
+            repo.save(obj);
+        }
+    }
 }

--- a/biblio/src/main/java/com/biblio/service/UtilisateurServiceImpl.java
+++ b/biblio/src/main/java/com/biblio/service/UtilisateurServiceImpl.java
@@ -3,6 +3,7 @@ package com.biblio.service;
 import org.springframework.stereotype.Service;
 import org.springframework.beans.factory.annotation.Autowired;
 import java.util.*;
+import java.time.*;
 import com.biblio.repository.UtilisateurRepository;
 import com.biblio.model.Utilisateur;
 
@@ -11,8 +12,14 @@ public class UtilisateurServiceImpl implements UtilisateurService {
     @Autowired
     private UtilisateurRepository repo;
 
-    public List<Utilisateur> findAll() { return repo.findAll(); }
-    public Utilisateur findById(Integer id) { return repo.findById(id).orElse(null); }
+    public List<Utilisateur> findAll() { return repo.findByDeleted_atIsNull(); }
+    public Utilisateur findById(Integer id) { return repo.findByIdAndDeleted_atIsNull(id).orElse(null); }
     public Utilisateur save(Utilisateur obj) { return repo.save(obj); }
-    public void deleteById(Integer id) { repo.deleteById(id); }
+    public void deleteById(Integer id) {
+        Utilisateur obj = repo.findById(id).orElse(null);
+        if(obj != null) {
+            obj.setDeleted_at(LocalDateTime.now());
+            repo.save(obj);
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- add `deleted_at` column to key entity models
- update repositories with methods ignoring deleted records
- update service implementations to mark deletion timestamp instead of removing records

## Testing
- `mvn test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6864310658c08331868428626e298638